### PR TITLE
update slash commands from api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,10 @@ go 1.21
 require (
 	github.com/mattermost/mattermost/server/public v0.0.14
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.8.4
 )
 
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dyatlov/go-opengraph/opengraph v0.0.0-20220524092352-606d7b1e5f8a // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
@@ -33,7 +31,6 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/tinylib/msgp v1.1.9 // indirect
@@ -50,5 +47,4 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/server/actions.go
+++ b/server/actions.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+type actionDefinitions map[string][]string
+
+func createActionDefinitionsFromJSON(data []byte) (actionDefinitions, error) {
+	var definitions actionDefinitions
+	if err := json.Unmarshal(data, &definitions); err != nil {
+		return nil, fmt.Errorf("can't unmarshal: %w, %s", err, data)
+	}
+	return definitions, nil
+}
+
+func (defs actionDefinitions) actions() ([]string, error) {
+	actions, ok := defs["actions"]
+	if !ok {
+		return nil, errors.New("no actions specified")
+	}
+	return actions, nil
+}
+
+func (defs actionDefinitions) commandFromAction(action string) (*model.Command, error) {
+	tokens := strings.Split(action, " ")
+	if len(tokens) < 1 {
+		return nil, errors.New("definition is empty")
+	}
+	autocompleteData := model.NewAutocompleteData(tokens[0], "", "")
+	for _, token := range tokens[1:] {
+		var items []model.AutocompleteListItem
+		for _, arg := range defs[token] {
+			items = append(items, model.AutocompleteListItem{
+				Item:     arg,
+				HelpText: token,
+			})
+		}
+		autocompleteData.AddStaticListArgument(token, true, items)
+	}
+	return &model.Command{
+		Trigger:          tokens[0],
+		AutoComplete:     true,
+		AutocompleteData: autocompleteData,
+	}, nil
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/mattermost/mattermost/server/public/pluginapi/cluster"
+)
+
+// Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.
+type Plugin struct {
+	plugin.MattermostPlugin
+
+	// configurationLock synchronizes access to the configuration.
+	configurationLock sync.RWMutex
+
+	// configuration is the active plugin configuration. Consult getConfiguration and
+	// setConfiguration for usage.
+	configuration *configuration
+}
+
+func updateSlashActions(client *pluginapi.Client, etag *string) error {
+	req, err := http.NewRequest("GET", "http://localhost:3000/list-actions", nil)
+	if err != nil {
+		return fmt.Errorf("can't create req: %w", err)
+	}
+	req.Header.Add("If-None-Match", *etag)
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("can't get: %w", err)
+	}
+	defer resp.Body.Close()
+	*etag = resp.Header.Get("Etag")
+
+	// nothing to do
+	if resp.StatusCode == 304 {
+		client.Log.Info("Slash actions already up to date")
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("can't read: %w", err)
+	}
+
+	definitions, err := createActionDefinitionsFromJSON(body)
+	if err != nil {
+		return err
+	}
+
+	actions, err := definitions.actions()
+	if err != nil {
+		return err
+	}
+
+	for _, action := range actions {
+		command, err := definitions.commandFromAction(action)
+		if err != nil {
+			return err
+		}
+		if err := client.SlashCommand.Register(command); err != nil {
+			return err
+		}
+	}
+
+	client.Log.Info("Slash actions updated")
+
+	return nil
+}
+
+// OnActivate is invoked when the plugin is activated.
+func (p *Plugin) OnActivate() error {
+	var etag string
+	client := pluginapi.NewClient(p.API, p.Driver)
+	_, err := cluster.Schedule(p.API, "UpdateSlashActions", cluster.MakeWaitForInterval(2*time.Second), func() {
+		p.API.LogInfo("Updating slash actions")
+		if err := updateSlashActions(client, &etag); err != nil {
+			p.API.LogError("error updating slash actions", "error", err)
+		}
+	})
+	return err
+}
+
+// ExecuteCommand executes a command that has been previously registered via the RegisterCommand API.
+func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	return &model.CommandResponse{
+		ResponseType: model.CommandResponseTypeEphemeral,
+		Text:         "Unknown command: " + args.Command,
+	}, nil
+}


### PR DESCRIPTION
#### Overview

This PR introduces a new plugin that pulls slash command definitions from an external API, and creates those slash commands on the local mattermost instance. We check if the definitions have changed every 2 seconds, and update the available slash commands accordingly.

The created slash commands don't currently do anything - that will come in a later update.

The API for this can be found here: https://github.com/maxwellpower/mm-servicebot

Which returns a response in the form:
```json
{
  "actions": [
    "delete-database environment database"
  ],
  "database": [
    "db1",
    "db2"
  ],
  "environment": [
    "production",
    "staging",
    "testing",
    "development"
  ]
}
```

The above `delete-database` action could map to a slash command in the form: `/delete-database staging db1`.

#### Limitations

This is for a demo, so I did not spend a lot of time architecting a clean implementation, and I took a few short cuts. A few notable ones:

- There are no tests
- There's no mechanism for authentication or authorization
- The external API URL is hardcoded
- When the slash command definitions change, I don't remove commands that have been undefined
- The polling rate to hit the external API is hardcoded

Let me know if any of these limitations are unacceptable, and I can address them. Or if you can think of other things that need to be fixed, I'm happy to do that, too :slightly_smiling_face: 